### PR TITLE
Workaround for XCFramework

### DIFF
--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -21,17 +21,16 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).all {
 kotlin {
     android()
 
-    // workaround: select iOS target platform depending on the Xcode environment variables
     // The multiplatform libraries do not support hierarchical structures, which breaks the IDE's completion.
     // https://kotlinlang.org/docs/mpp-share-on-platforms.html#share-code-on-similar-platforms
-    if (System.getenv("SDK_NAME")?.startsWith("iphoneos")) {
-        iosArm64("ios")
-    } else {
-        iosX64("ios")
-    }
-
-    targets.getByName("ios").binaries.forEach {
-        it.linkerOpts.add("-lsqlite3")
+    def iosTargets = [
+            iosArm64("ios"),
+            iosX64()
+    ]
+    iosTargets.forEach {
+        it.binaries.forEach {
+            it.linkerOpts.add("-lsqlite3")
+        }
     }
 
     sourceSets {
@@ -91,9 +90,12 @@ kotlin {
                 srcDir 'src/androidTest'
             }
         }
-        iosMain.dependencies {
-            implementation Dep.Ktor.ios
-            implementation Dep.Koin.core
+        iosMain {
+            it.dependencies {
+                implementation Dep.Ktor.ios
+                implementation Dep.Koin.core
+            }
+            iosX64Main.dependsOn(it)
         }
 //            // For instrumentation tests
 //            androidTestImplementation  "com.google.dagger:hilt-android-testing:2.31.2-alpha"

--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -90,17 +90,11 @@ kotlin {
                 srcDir 'src/androidTest'
             }
         }
-        iosMain {
-            it.dependencies {
-                implementation Dep.Ktor.ios
-                implementation Dep.Koin.core
-            }
-            iosX64Main.dependsOn(it)
+        iosMain.dependencies {
+            implementation Dep.Ktor.ios
+            implementation Dep.Koin.core
         }
-//            // For instrumentation tests
-//            androidTestImplementation  "com.google.dagger:hilt-android-testing:2.31.2-alpha"
-//            kaptAndroidTest Dep.Dagger.hiltAndroidCompiler
-//        }
+        iosX64Main.dependsOn(iosMain)
     }
 }
 

--- a/data/db/build.gradle
+++ b/data/db/build.gradle
@@ -88,13 +88,11 @@ kotlin {
 //            androidTestImplementation  "com.google.dagger:hilt-android-testing:2.31.2-alpha"
 //            kaptAndroidTest Dep.Dagger.hiltAndroidCompiler
 //        }
-        iosMain {
-            it.dependencies {
-                implementation Dep.Koin.core
-                implementation "com.squareup.sqldelight:native-driver:1.4.4"
-            }
-            iosX64Main.dependsOn(it)
+        iosMain.dependencies {
+            implementation Dep.Koin.core
+            implementation "com.squareup.sqldelight:native-driver:1.4.4"
         }
+        iosX64Main.dependsOn(iosMain)
     }
 }
 

--- a/data/db/build.gradle
+++ b/data/db/build.gradle
@@ -22,17 +22,16 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).all {
 kotlin {
     android()
 
-    // workaround: select iOS target platform depending on the Xcode environment variables
     // The multiplatform libraries do not support hierarchical structures, which breaks the IDE's completion.
     // https://kotlinlang.org/docs/mpp-share-on-platforms.html#share-code-on-similar-platforms
-    if (System.getenv("SDK_NAME")?.startsWith("iphoneos")) {
-        iosArm64("ios")
-    } else {
-        iosX64("ios")
-    }
-
-    targets.getByName("ios").binaries.forEach {
-        it.linkerOpts.add("-lsqlite3")
+    def iosTargets = [
+            iosArm64("ios"),
+            iosX64()
+    ]
+    iosTargets.forEach {
+        it.binaries.forEach {
+            it.linkerOpts.add("-lsqlite3")
+        }
     }
 
     sourceSets {
@@ -89,9 +88,12 @@ kotlin {
 //            androidTestImplementation  "com.google.dagger:hilt-android-testing:2.31.2-alpha"
 //            kaptAndroidTest Dep.Dagger.hiltAndroidCompiler
 //        }
-        iosMain.dependencies {
-            implementation Dep.Koin.core
-            implementation "com.squareup.sqldelight:native-driver:1.4.4"
+        iosMain {
+            it.dependencies {
+                implementation Dep.Koin.core
+                implementation "com.squareup.sqldelight:native-driver:1.4.4"
+            }
+            iosX64Main.dependsOn(it)
         }
     }
 }

--- a/data/repository/build.gradle
+++ b/data/repository/build.gradle
@@ -21,17 +21,16 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile.class).all {
 kotlin {
     android()
 
-    // workaround: select iOS target platform depending on the Xcode environment variables
     // The multiplatform libraries do not support hierarchical structures, which breaks the IDE's completion.
     // https://kotlinlang.org/docs/mpp-share-on-platforms.html#share-code-on-similar-platforms
-    if (System.getenv("SDK_NAME")?.startsWith("iphoneos")) {
-        iosArm64("ios")
-    } else {
-        iosX64("ios")
-    }
-
-    targets.getByName("ios").binaries.forEach {
-        it.linkerOpts.add("-lsqlite3")
+    def iosTargets = [
+            iosArm64("ios"),
+            iosX64()
+    ]
+    iosTargets.forEach {
+        it.binaries.forEach {
+            it.linkerOpts.add("-lsqlite3")
+        }
     }
 
     sourceSets {
@@ -75,8 +74,11 @@ kotlin {
                 srcDir 'src/androidTest'
             }
         }
-        iosMain.dependencies {
-            implementation Dep.Koin.core
+        iosMain {
+            it.dependencies {
+                implementation Dep.Koin.core
+            }
+            iosX64Main.dependsOn(it)
         }
     }
 }

--- a/data/repository/build.gradle
+++ b/data/repository/build.gradle
@@ -74,12 +74,10 @@ kotlin {
                 srcDir 'src/androidTest'
             }
         }
-        iosMain {
-            it.dependencies {
-                implementation Dep.Koin.core
-            }
-            iosX64Main.dependsOn(it)
+        iosMain.dependencies {
+            implementation Dep.Koin.core
         }
+        iosX64Main.dependsOn(iosMain)
     }
 }
 

--- a/ios-framework/build.gradle.kts
+++ b/ios-framework/build.gradle.kts
@@ -61,19 +61,6 @@ kotlin {
     }
 }
 
-val packForXcode by tasks.creating(Sync::class) {
-    group = "build"
-    val mode = System.getenv("CONFIGURATION") ?: "DEBUG"
-    val framework =
-        kotlin.targets.getByName<KotlinNativeTarget>("ios").binaries.getFramework(mode)
-    inputs.property("mode", mode)
-    dependsOn(framework.linkTask)
-    val targetDir = File(buildDir, "xcode-frameworks")
-    from({ framework.outputDirectory })
-    into(targetDir)
-}
-tasks.getByName("build").dependsOn(packForXcode)
-
 // Workaround for issues where types defined in iOS native code cannot be referenced in Android Studio
 tasks.getByName("preBuild").dependsOn(tasks.getByName("compileKotlinIos"))
 
@@ -83,4 +70,11 @@ multiplatformSwiftPackage {
         iOS { v("14") }
     }
     outputDirectory(File(projectDir, "../ios/build/xcframeworks"))
+    buildConfiguration {
+        if (System.getenv("CONFIGURATION") != "Release") {
+            debug()
+        } else {
+            release()
+        }
+    }
 }

--- a/ios-framework/build.gradle.kts
+++ b/ios-framework/build.gradle.kts
@@ -50,12 +50,13 @@ kotlin {
                 implementation(kotlin("test-annotations-common"))
             }
         }
-        val iosX64Main by getting
         val iosMain by getting {
             dependencies {
                 implementation(Dep.Koin.core)
             }
-            iosX64Main.dependsOn(this)
+        }
+        val iosX64Main by getting {
+            dependsOn(iosMain)
         }
         val iosTest by getting
     }

--- a/ios-framework/build.gradle.kts
+++ b/ios-framework/build.gradle.kts
@@ -13,14 +13,12 @@ apply(rootProject.file("gradle/android.gradle"))
 kotlin {
     android()
 
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        if (System.getenv("SDK_NAME")?.startsWith("iphoneos") == true)
-            ::iosArm64
-        else
-            ::iosX64
-
-    iosTarget("ios") {
-        binaries {
+    val iosTargets = listOf(
+        iosArm64("ios"),
+        iosX64()
+    )
+    iosTargets.forEach {
+        it.binaries {
             framework {
                 baseName = "DroidKaigiMPP"
                 export(project(":model"))
@@ -52,10 +50,12 @@ kotlin {
                 implementation(kotlin("test-annotations-common"))
             }
         }
+        val iosX64Main by getting
         val iosMain by getting {
             dependencies {
                 implementation(Dep.Koin.core)
             }
+            iosX64Main.dependsOn(this)
         }
         val iosTest by getting
     }

--- a/ios/scripts/create-kmm-framework.sh
+++ b/ios/scripts/create-kmm-framework.sh
@@ -4,4 +4,4 @@ SHELL_PATH=`pwd -P`
 
 cd "$SHELL_PATH/../../"
 
-./gradlew :ios-framework:packForXCode -PXCODE_CONFIGURATION=${CONFIGURATION}
+./gradlew ios-framework:createXCFramework


### PR DESCRIPTION
## Overview (Required)

- Create targets both for ARM64 and X64 to build XCFramework
- Rename one of them to `ios` to keep the original workaround working
- Set another one depends on `ios`
- Migrate `packForXCode` to `createXCFramework`

## Links

- [Original workaround](https://kotlinlang.org/docs/mobile/add-dependencies.html#workaround-to-enable-ide-support-for-the-shared-ios-source-set)
